### PR TITLE
[CTD-284] add new platformTypes so that /project/create API does not fail.

### DIFF
--- a/connectd/usr/bin/connectd_library
+++ b/connectd/usr/bin/connectd_library
@@ -1193,19 +1193,25 @@ installProvisioning()
     if [ ! -d "$CONNECTD_CONF_DIR" ]; then
 	mkdir -p "$CONNECTD_CONF_DIR"
     fi
+
 # calculate the project name, given the PLATFORM and PROTOCOL
-    if [ "$PLATFORM" = "x86-etch" ]; then
+# in some cases where there is a "static" version, we grep
+# the base file extension to match static and non static
+
+    if [ $(echo "$PLATFORM" | grep "x86-etch") != "" ]; then
         platformType="4B2"
-    elif [ "$PLATFORM" = "x86_64-etch" ]; then
+    elif [ $(echo "$PLATFORM" | grep "x86_64-etch") != "" ]; then
         platformType="4B2"
-    elif [ "$PLATFORM" = "x86_64-ubuntu16.04" ]; then
+    elif [ $(echo "$PLATFORM" | grep "x86-ubuntu16.04") != "" ]; then
         platformType="460"
-    elif [ "$PLATFORM" = "x86-ubuntu16.04" ]; then
+    elif [ $(echo "$PLATFORM" | grep "x86_64-ubuntu16.04") != "" ]; then
         platformType="460"
     elif [ "$PLATFORM" = "arm-linaro-pi" ]; then
         platformType="430"
     elif [ $(echo "$PLATFORM" | grep "arm") != "" ]; then
-        platformtype="4B0"
+        platformType="4B0"
+    elif [ $(echo "$PLATFORM" | grep "mips") != "" ]; then
+        platformType="4B1"
     else
        echo "Not currently supported: $PLATFORM"
        echo "Please contact support@remote.it."


### PR DESCRIPTION
"arm64" daemons were not handled correctly due to typo in "platformType" variable.  
Also changed exact match of "PLATFORM" for all platformTypes to match a full or substring using grep, in order to match static daemon versions of the same architecture.
e.g. x86-etch and x86-etch_static are both handled by the same case.
Also added "mips" case even though we are not building any mips targets at the moment.