### PR TITLE
[CTD-298] added double quotes to expressions which were throwing warnings

### DIFF
--- a/connectd/DEBIAN/control
+++ b/connectd/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: connectd
-Version: 2.2.8
+Version: 2.2.10
 Section: non-free/net
 Priority: optional
 Homepage: https://remote.it

--- a/connectd/usr/bin/connectd_library
+++ b/connectd/usr/bin/connectd_library
@@ -1189,19 +1189,19 @@ installProvisioning()
 # in some cases where there is a "static" version, we grep
 # the base file extension to match static and non static
 
-    if [ $(echo "$PLATFORM" | grep "x86-etch") != "" ]; then
+    if [ "$(echo "$PLATFORM" | grep "x86-etch")" != "" ]; then
         platformType="4B2"
-    elif [ $(echo "$PLATFORM" | grep "x86_64-etch") != "" ]; then
+    elif [ "$(echo "$PLATFORM" | grep "x86_64-etch")" != "" ]; then
         platformType="4B2"
-    elif [ $(echo "$PLATFORM" | grep "x86-ubuntu16.04") != "" ]; then
+    elif [ "$(echo "$PLATFORM" | grep "x86-ubuntu16.04")" != "" ]; then
         platformType="460"
-    elif [ $(echo "$PLATFORM" | grep "x86_64-ubuntu16.04") != "" ]; then
+    elif [ "$(echo "$PLATFORM" | grep "x86_64-ubuntu16.04")" != "" ]; then
         platformType="460"
     elif [ "$PLATFORM" = "arm-linaro-pi" ]; then
         platformType="430"
-    elif [ $(echo "$PLATFORM" | grep "arm") != "" ]; then
+    elif [ "$(echo "$PLATFORM" | grep "arm")" != "" ]; then
         platformType="4B0"
-    elif [ $(echo "$PLATFORM" | grep "mips") != "" ]; then
+    elif [ "$(echo "$PLATFORM" | grep "mips")" != "" ]; then
         platformType="4B1"
     else
        echo "Not currently supported: $PLATFORM"


### PR DESCRIPTION
when running the interactive installer.  This issue got introduced after
the Pi release was sent to Pi foundation, so no need to update them for
this issue.