### PR TITLE
CTD-412 resolve github security alerts re: Axios 0.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
       "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
         "follow-redirects": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "download-assets": "ts-node scripts/download-assets.ts"
   },
   "dependencies": {
-    "axios": "0.18.0",
+    "axios": "0.18.1",
     "ts-node": "8.0.2",
     "typescript": "3.2.4"
   },


### PR DESCRIPTION
The security alert pointed to package-lock.json, however the dependencies block is in package.json.  I changes the axios reference from 0.18.0 to 0.18.1 in both places.  There is a hint that package-lock.json is a generated file and so maybe changing that one is not necessary.