### PR TITLE
CTD-430 fix API endpoint to be used when script fails

### DIFF
--- a/connectd/usr/bin/connectd_task_notify
+++ b/connectd/usr/bin/connectd_task_notify
@@ -20,8 +20,8 @@
 #
 
 #### Settings #####
-VERSION=1.0
-MODIFIED="January 02, 2019"
+VERSION=1.1
+MODIFIED="January 07, 2020"
 #
 # Log to system log if set to 1
 LOGGING=1
@@ -255,7 +255,7 @@ case $cmd in
         #
         # Task Failed 
         #
-        URL="$apiMethod$api_base$API_TASK_DONE"
+        URL="$apiMethod$api_base$API_TASK_FAILED"
         data="{\"taskid\":\"${task_id}\",\"description\":\"${status}\"}"
 
         resp=$($CURL $CURL_OPTS 'POST' -w "%{http_code}\\n" -o "$OUTPUT" $URL -d "$data")


### PR DESCRIPTION
API endpoint for "failed" scenario has apparently been incorrect for quite some time!