### PR TITLE
CTD-434

### DIFF
--- a/connectd/usr/bin/connectd_library
+++ b/connectd/usr/bin/connectd_library
@@ -945,14 +945,17 @@ deleteAllConnections()
 	    rm "$BIN_DIR"/"$STARTEMUP"
 #            rm "$BIN_DIR"/Connectd*
        fi
-# also should disable daemon startup at this point
-       disableStartup
-# stop the connectd and schannel daemons using systemd
-# we already stopped the connectd daemons but doing this
-# keeps systemd in sync
+      availableDir="/etc/connectd/available"
+      if ! ([ -d $availableDir ] && [ "$(ls -A $availableDir)" ]); then
+        # also should disable daemon startup at this point
+        disableStartup
+        # stop the connectd and schannel daemons using systemd
+        # we already stopped the connectd daemons but doing this
+        # keeps systemd in sync
         systemctl stop connectd
         systemctl stop connectd_schannel
         exit
+      fi
     fi
 }
 

--- a/connectd/usr/bin/connectd_library
+++ b/connectd/usr/bin/connectd_library
@@ -945,7 +945,7 @@ deleteAllConnections()
 	    rm "$BIN_DIR"/"$STARTEMUP"
 #            rm "$BIN_DIR"/Connectd*
        fi
-      availableDir="/etc/connectd/available"
+      availableDir="${CONNECTD_DIR}/available"
       if ! ([ -d $availableDir ] && [ "$(ls -A $availableDir)" ]); then
         # also should disable daemon startup at this point
         disableStartup


### PR DESCRIPTION
https://remoteit.atlassian.net/browse/CTD-434

Uninstalling all services with connectd_installer disables connectd and connectd_schannel even if bulk reg services are there
  - Check if available directory exists before disabling connectd and connectd_schannel