### PR TITLE
CTD-478

### DIFF
--- a/connectd/usr/bin/connectd_library
+++ b/connectd/usr/bin/connectd_library
@@ -823,7 +823,8 @@ checkAPIResult()
     else
         printf "\nAPI call to $1 failed!\n"
         reason=$(jsonval "$2" 'reason')
-        echo "Reason for failure: $reason"
+        errorcode=$(jsonval "$2" 'code')
+        echo "Reason for failure: $reason, Error code: $errorcode."
         echo "Contact support@remote.it with this information."
         echo "Please press the ENTER key."
         echo


### PR DESCRIPTION
https://remoteit.atlassian.net/browse/CTD-478

In the case of API failure, show "code" in addition to "reason"

  - Show error code