### PR TITLE
CTD-539 remove extra slash in paths

### DIFF
--- a/connectd/usr/bin/connectd_claimcode
+++ b/connectd/usr/bin/connectd_claimcode
@@ -9,7 +9,7 @@
 #
 #  remot3.it, Inc. : https://remote.it
 
-BASEDIR=
+BASEDIR=$CONNECTD_BASEDIR
 CONNECTD_DIR="$BASEDIR"/etc/connectd
 # pick up global options, e.g. PLATFORM and API
 . "$CONNECTD_DIR"/oem_settings

--- a/connectd/usr/bin/connectd_control
+++ b/connectd/usr/bin/connectd_control
@@ -881,7 +881,7 @@ deviceReset()
     # reset is a collection of standard tasks
     sudo /usr/bin/connectd_stop_all
     sudo connectd_control stop all
-    sudo connectd_control reset "y"
+    sudo connectd_control reset y
 
     # archive the current pre-reset settings - just in case
 	if [ -f "/etc/connectd/hardware_id.txt" ]; then

--- a/connectd/usr/bin/connectd_library
+++ b/connectd/usr/bin/connectd_library
@@ -1523,10 +1523,12 @@ disableStartup()
 setBASEDIR()
 {
 # echo "setBASEDIR for $1"
-    # have to escape slashes / in path to send string to sed
-    BASEDIRSTRING=$(echo "$BASEDIR" | sed 's/\//\\\//g')
-    cat "$1" | sed "/BASEDIR=/c\BASEDIR=$BASEDIRSTRING/" > "$TMP_DIR"/setBASEDIR.tmp 
-    cp "$TMP_DIR"/setBASEDIR.tmp "$1" 
+    if [ "$BASEDIR" != "" ]; then
+        # have to escape slashes / in path to send string to sed
+        BASEDIRSTRING=$(echo "$BASEDIR" | sed 's/\//\\\//g')
+        cat "$1" | sed "/BASEDIR=/c\BASEDIR=$BASEDIRSTRING/" > "$TMP_DIR"/setBASEDIR.tmp 
+        cp "$TMP_DIR"/setBASEDIR.tmp "$1" 
+    fi
 }
 
 #----------  end of setBASEDIR --------------

--- a/connectd/usr/bin/connectd_mp_configure
+++ b/connectd/usr/bin/connectd_mp_configure
@@ -5,7 +5,7 @@
 #  remot3.it, Inc. : https://remote.it
 #
 
-BASEDIR=
+BASEDIR=$CONNECTD_BASEDIR
 CONNECTD_DIR="$BASEDIR"/etc/connectd
 # pick up global options, e.g. PLATFORM and API
 . "$CONNECTD_DIR"/oem_settings

--- a/connectd/usr/bin/connectd_options
+++ b/connectd/usr/bin/connectd_options
@@ -7,9 +7,9 @@
 #  Any script which includes this file must have #!/bin/sh as its first line.
 #  connectd_options is never executed directly.
 #===================================
-MODIFIED="June 07, 2020"
+MODIFIED="June 10, 2020"
 #===================================
-BUILDDATE=
+BUILDDATE="Thu Jun 11 11:44:47 PDT 2020"    
 #===================================
 VERSION=
 #===================================
@@ -22,7 +22,7 @@ DEBUG="0"
 EXITONAPIERROR="1"
 #===================================
 # BASEDIR is root on many systems. If so, leave it blank, else set the enviorment variable $CONNECTD_BASEDIR
-#BASEDIR=$CONNECTD_BASEDIR | sed 's/\/*$//g'
+BASEDIR=$CONNECTD_BASEDIR
 #===================================
 # BIN_DIR is default path for executables.  We install connectd scripts and binaries here.
 BIN_DIR="$BASEDIR"/usr/bin

--- a/test/Interactive/interactive-test.sh
+++ b/test/Interactive/interactive-test.sh
@@ -12,12 +12,10 @@ checkForRoot
 # If run with no following parameter, just run the script interactively
 # while capturing the debug output (e.g. for manual testing).
 if [ "$1" = "" ]; then
-#    sudo sh -x /usr/bin/connectd_installer 2> debug.txt | tee console.txt
     sudo sh -x /usr/bin/connectd_installer 2> /tmp/debug.txt | tee /tmp/console.txt
 else
 # If run with one following parameter, use that parameter as the name of a keystroke file
 # such as configure-01.key, configure-02.key, remove-all.key
-#    sudo sh -x /usr/bin/connectd_installer < "$1" 2> debug.txt | tee console.txt
     sudo sh -x /usr/bin/connectd_installer < "$1" 2> /tmp/debug.txt | tee /tmp/console.txt
 fi
 


### PR DESCRIPTION
when using interactive installer.  Previous fix by Mani performed a sed replace "//" with "/" in the generated path.  This time we prevent the double slash problem from happening in the first place.