### PR TITLE
CTD-619 problem with auto- install.sh

### DIFF
--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -7,7 +7,7 @@
 #       GSW.
 
 VERSION=2.6.39
-# call out the exact version of connectd used for this version of installer
+# call out the exact versions of binaries used for this version of installer
 # prevents failure when "latest" changes the name of any daemon
 CONNECTDVERSION=v4.12.0
 BUILDPATH=https://github.com/remoteit/installer/releases/download/v$VERSION
@@ -70,71 +70,6 @@ downloadAndTestDaemon()
     fi
     return $retval
 }
-
-downloadSchannel()
-{
-    local testArch=$1
-    local testDaemon=schannel."$testArch"
-    local retval=0
-
-    printf "\n"
-    printf "%s\n" "Downloading and testing $testDaemon..." | tee -a $LOGFILE   
-    if [ ! -e "$testDaemon" ]; then
-        curl -sfLkO "https://github.com/remoteit/multiport/releases/latest/download/${testDaemon}" > /dev/null
-        if [ "$?" != "0" ]; then
-            printf "%s\n" "$testDaemon download failed!" | tee -a $LOGFILE           
-	    exit 1
-        fi
-    fi
-    sleep 2
-    chmod +x "$testDaemon"
-    mv $testDaemon /usr/bin/connectd_"$testDaemon"
-    ln -sf /usr/bin/connectd_"$testDaemon" "/usr/bin/connectd_schannel"
-    echo $retval
-}
-
-
-
-downMultiport()
-{
-    local testArch=$1
-    local muxer="muxer"
-    local demuxer="demuxer"
-    local muxerDaemon="${muxer}.${testArch}"
-    local demuxerDaemon="${demuxer}.${testArch}"
-    local retval=0
-
-    printf "\n"
-    printf "%s\n" "Downloading and testing $muxerDaemon..." | tee -a $LOGFILE
-    if [ ! -e "$muxerDaemon" ]; then
-        curl -sfLkO "https://github.com/remoteit/multiport/releases/latest/download/${muxerDaemon}" >> $LOGFILE
-        if [ "$?" != "0" ]; then
-            printf "%s\n" "$muxerDaemon download failed!" | tee -a $LOGFILE
-            exit 1
-        fi
-    fi
-    #
-    # link it and chmod it
-    chmod +x "$muxerDaemon"
-    mv $muxerDaemon "/usr/bin/connectd_${muxerDaemon}"
-    ln -sf "/usr/bin/connectd_${muxerDaemon}" "/usr/bin/connectd_${muxer}"
-
-    printf "\n"
-    printf "%s\n" "Downloading and testing $demuxerDaemon..." | tee -a $LOGFILE
-    if [ ! -e "$demuxerDaemon" ]; then
-        curl -sfLkO "https://github.com/remoteit/multiport/releases/latest/download/${demuxerDaemon}" >> $LOGFILE
-        if [ "$?" != "0" ]; then
-            printf "%s\n" "$demuxerDaemon download failed!" | tee -a $LOGFILE
-            exit 1
-        fi
-    fi    
-    sleep 2
-    chmod +x "$demuxerDaemon"
-    mv $demuxerDaemon /usr/bin/connectd_"$demuxerDaemon"
-    ln -sf "/usr/bin/connectd_${demuxerDaemon}" "/usr/bin/connectd_${demuxer}"
-    echo $retval
-}
-
 
 # when using Debian package we have to check for compatibility with older versions
 # and use the older daemon if the newer one doesn't work.  If the older daemon gets used,
@@ -407,8 +342,6 @@ if [ $useTar -eq 1 ]; then
         fi
     fi
 
-    downMultiport "$daemon"
-    
     currentFolder=$(pwd)
     filename=connectd_"$VERSION"_"$daemon"".tar"
 

--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -7,6 +7,9 @@
 #       GSW.
 
 VERSION=2.6.39
+# call out the exact version of connectd used for this version of installer
+# prevents failure when "latest" changes the name of any daemon
+CONNECTDVERSION=v4.12.0
 BUILDPATH=https://github.com/remoteit/installer/releases/download/v$VERSION
 LOGFILE=remote.itBinaryTestLog.txt
 
@@ -46,7 +49,7 @@ downloadAndTestDaemon()
     printf "\n"
     printf "%s\n" "Downloading and testing $testDaemon..." | tee -a $LOGFILE
     if [ ! -e "$testDaemon" ]; then
-        curl -sfLkO "https://github.com/remoteit/connectd/releases/latest/download/${testDaemon}" > /dev/null
+        curl -sfLkO "https://github.com/remoteit/connectd/releases/download/$CONNECTDVERSION/${testDaemon}" > /dev/null
         if [ "$?" != "0" ]; then
             printf "%s\n" "$testDaemon download failed!" | tee -a $LOGFILE
             exit 1

--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -7,8 +7,8 @@
 #       GSW.
 
 VERSION=2.6.39
-# call out the exact versions of binaries used for this version of installer
-# prevents failure when "latest" changes the name of any daemon
+# call out the exact version of connectd binary used in this version of installer
+# prevents failure when "latest" release changes the name of any daemon
 CONNECTDVERSION=v4.12.0
 BUILDPATH=https://github.com/remoteit/installer/releases/download/v$VERSION
 LOGFILE=remote.itBinaryTestLog.txt


### PR DESCRIPTION
Unit test results.

`gary@Old-Gigabyte:~$ sudo ./auto-install.sh 

 curl found 
********************************************************
remote.it platform and binary tester version 2.6.39 
Current directory /home/gary
Fri May 21 09:17:04 PDT 2021
********************************************************
Linux Old-Gigabyte 5.4.0-72-generic #80~18.04.1-Ubuntu SMP Mon Apr 12 23:26:25 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
Detected architecture is x86_64
/usr/bin/dpkg
Debian OS detected.
amd64 architecture detected.

Downloading and testing connectd.x86_64-ubuntu16.04...
Looks compatible.
connectd.x86_64-ubuntu16.04 is compatible!
filename connectd_2.6.39_amd64.deb
filepath https://github.com/remoteit/installer/releases/download/v2.6.39/connectd_2.6.39_amd64.deb
(Reading database ... 308084 files and directories currently installed.)
Preparing to unpack connectd_2.6.39_amd64.deb ...
Unpacking connectd (2.6.39) over (2.6.39) ...
Setting up connectd (2.6.39) ...

================================================================================
Run "sudo connectd_installer" to interactively install remote.it Services on this device.

See https://support.remote.it/hc/en-us/sections/360010786372-Using-the-connectd-package
for more information.

================================================================================
gary@Old-Gigabyte:~$ 
`