### PR TITLE
CTD 693 update connectd readme and auto install to point at new method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 ## Please note, the connectd package is deprecated and not recommended for new installs.
 
+Please find the new instructions for single-device installation at: https://link.remote.it/support/rpi-linux-quick-install
+
 [![CircleCI](https://circleci.com/gh/remoteit/installer.svg?style=svg&circle-token=51d69d01d1536ee58ad7ddf3ae927811416fee63)](https://circleci.com/gh/remoteit/installer)
 
 > System tools for setting up remote.it on your internet connected devices.

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@
 ## Please note, the connectd package is deprecated and not recommended for new installs.
 
 Please find the new instructions for single-device installation at: https://link.remote.it/support/rpi-linux-quick-install
+
 To prepare an OS image for mass production that will register a pre-defined set of Remote.It Services, please see: https://link.remote.it/docs/oem-overview
 
 [![CircleCI](https://circleci.com/gh/remoteit/installer.svg?style=svg&circle-token=51d69d01d1536ee58ad7ddf3ae927811416fee63)](https://circleci.com/gh/remoteit/installer)

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@
 ## Please note, the connectd package is deprecated and not recommended for new installs.
 
 Please find the new instructions for single-device installation at: https://link.remote.it/support/rpi-linux-quick-install
+To prepare an OS image for mass production that will register a pre-defined set of Remote.It Services, please see: https://link.remote.it/docs/oem-overview
 
 [![CircleCI](https://circleci.com/gh/remoteit/installer.svg?style=svg&circle-token=51d69d01d1536ee58ad7ddf3ae927811416fee63)](https://circleci.com/gh/remoteit/installer)
 

--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -13,6 +13,19 @@ CONNECTDVERSION=v4.12.0
 BUILDPATH=https://github.com/remoteit/installer/releases/download/v$VERSION
 LOGFILE=remote.itBinaryTestLog.txt
 
+show_deprecation_warning() {
+
+    echo "The connectd package has been deprecated.  We do not recommend this package for production."
+    echo "Please find the new instructions for single-device installation at:"
+    echo "https://link.remote.it/support/rpi-linux-quick-install"
+    echo
+    echo "To prepare an OS image for mass production that will register a pre-defined set of Remote.It"
+    echo "Services, please see: https://link.remote.it/docs/oem-overview ."
+    echo
+    echo "Press any key to continue.  Press ^C to terminate this script."
+    read anyKey
+}
+
 # to install curl tool
 installCurl() {
     printf "\nInstalling curl..........\n"
@@ -115,6 +128,7 @@ checkForUtilities()
 
 # main program starts here
 #
+show_deprecation_warning
 # clear log file each time
 if [ -e $LOGFILE ]; then
     rm $LOGFILE


### PR DESCRIPTION
connectd package is deprecated.  These changes update the readme.md at Github to point to the new instructions.  The auto-install.sh is also modified to show this information when it first starts, and then asks the user to press a key to continue, meaning they have an opportunity to read the note.